### PR TITLE
Implement shared scaffold with floating navigation toolbar

### DIFF
--- a/Caffeine-in/app/src/main/java/com/example/caffeine_in/MainActivity.kt
+++ b/Caffeine-in/app/src/main/java/com/example/caffeine_in/MainActivity.kt
@@ -5,14 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.Surface
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
-import com.example.caffeine_in.ui.analysis.AnalysisScreen
-import com.example.caffeine_in.ui.caffeinetracker.CaffeineTrackerScreen
-import com.example.caffeine_in.ui.info.InfoScreen
-import com.example.caffeine_in.ui.settings.LicensesScreen
-import com.example.caffeine_in.ui.settings.SettingsScreen
+import com.example.caffeine_in.ui.navigation.CaffeineApp
 import com.example.caffeine_in.ui.theme.CaffeineinTheme
 
 class MainActivity : ComponentActivity() {
@@ -21,26 +14,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             CaffeineinTheme {
-                Surface {
-                    val navController = rememberNavController()
-                    NavHost(navController = navController, startDestination = "tracker") {
-                        composable("tracker") {
-                            CaffeineTrackerScreen(navController = navController)
-                        }
-                        composable("info") {
-                            InfoScreen(navController = navController)
-                        }
-                        composable("analysis") {
-                            AnalysisScreen(navController = navController)
-                        }
-                        composable("settings") {
-                            SettingsScreen(navController = navController)
-                        }
-                        composable("licenses") {
-                            LicensesScreen(navController = navController)
-                        }
-                    }
-                }
+                Surface { CaffeineApp() }
             }
         }
     }

--- a/Caffeine-in/app/src/main/java/com/example/caffeine_in/ui/analysis/AnalysisScreen.kt
+++ b/Caffeine-in/app/src/main/java/com/example/caffeine_in/ui/analysis/AnalysisScreen.kt
@@ -1,10 +1,7 @@
 package com.example.caffeine_in.ui.analysis
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -12,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -20,7 +16,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -36,28 +31,19 @@ fun AnalysisScreen(
     val intakeList by analysisViewModel.intakeList.collectAsState()
     val histogramData = analysisViewModel.getHistogramData()
 
-    Scaffold(
-        containerColor = Color(0xFFECE0D1),
-        topBar = {
-            AnalysisTopBar(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .statusBarsPadding(),
-                navController = navController
-            )
-        }
-    ) { innerPadding ->
-        val modifiedPadding = PaddingValues(
-            top = innerPadding.calculateTopPadding(),
-            start = innerPadding.calculateStartPadding(LocalLayoutDirection.current),
-            end = innerPadding.calculateEndPadding(LocalLayoutDirection.current),
-            bottom = 0.dp
+    Column(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        AnalysisTopBar(
+            modifier = Modifier
+                .fillMaxWidth()
+                .statusBarsPadding(),
+            navController = navController
         )
 
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(modifiedPadding)
                 .padding(horizontal = 32.dp)
         ) {
             // histogram

--- a/Caffeine-in/app/src/main/java/com/example/caffeine_in/ui/caffeinetracker/CaffeineTrackerScreen.kt
+++ b/Caffeine-in/app/src/main/java/com/example/caffeine_in/ui/caffeinetracker/CaffeineTrackerScreen.kt
@@ -38,7 +38,6 @@ import com.example.caffeine_in.ui.caffeinetracker.components.HistoryHeader
 import com.example.caffeine_in.ui.caffeinetracker.components.IndicatorDialog
 import com.example.caffeine_in.ui.caffeinetracker.components.NewSourceFAB
 import com.example.caffeine_in.ui.caffeinetracker.components.TodaysTotalSection
-import com.example.caffeine_in.ui.caffeinetracker.components.ToolBarFAB
 import com.example.caffeine_in.ui.caffeinetracker.components.TopBar
 import com.example.caffeine_in.ui.theme.CaffeineinTheme
 import kotlinx.coroutines.Job
@@ -96,29 +95,21 @@ fun CaffeineTrackerScreen(
     }
     
     Scaffold(
-        /*topBar = {
+        topBar = {
             TopBar(
                 modifier = Modifier
                     .fillMaxWidth()
                     .statusBarsPadding(),
                 navController = navController
             )
-        },*/
-        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
-        containerColor = Color(0xFFECE0D1),
-        floatingActionButtonPosition = FabPosition.Center,
-        floatingActionButton = {
-            ToolBarFAB(
-                navController = navController,
-                onFabClick = { showAddDialog.value = true }
-            )
-        }
+        },
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
     ) { innerPadding ->
         val modifiedPadding = PaddingValues(
             top = innerPadding.calculateTopPadding(),
             start = innerPadding.calculateStartPadding(LocalLayoutDirection.current),
             end = innerPadding.calculateEndPadding(LocalLayoutDirection.current),
-            bottom = 0.dp
+            bottom = innerPadding.calculateBottomPadding()
         )
         
         Box(

--- a/Caffeine-in/app/src/main/java/com/example/caffeine_in/ui/caffeinetracker/components/FAB.kt
+++ b/Caffeine-in/app/src/main/java/com/example/caffeine_in/ui/caffeinetracker/components/FAB.kt
@@ -1,6 +1,5 @@
 package com.example.caffeine_in.ui.caffeinetracker.components
 
-import android.widget.Toolbar
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -15,18 +14,17 @@ import androidx.compose.material.icons.outlined.Coffee
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.FloatingToolbarColors
-import androidx.compose.material3.FloatingToolbarDefaults
 import androidx.compose.material3.FloatingToolbarHorizontalFabPosition
 import androidx.compose.material3.HorizontalFloatingToolbar
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonColors
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -62,25 +60,20 @@ fun NewSourceFAB(
     }
 }
 
-@ExperimentalMaterial3ExpressiveApi
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ToolBarFAB(
-    modifier: Modifier = Modifier,
     navController: NavController,
-    onFabClick: () -> Unit,
-    expanded: Boolean = true
+    currentDestination: String?,
+    onFabClick: () -> Unit
 ) {
-    val toolbarColors = FloatingToolbarColors(
-        toolbarContainerColor = Color(0xFFC5B5A6),
-        toolbarContentColor = Color(0xFF38220F),
-        fabContainerColor = Color(0xFFE57825),
-        fabContentColor = Color(0xFF38220F)
+    val items = listOf(
+        NavItem("analysis", Icons.Outlined.AutoGraph, "Analysis"),
+        NavItem("tracker", Icons.Outlined.Coffee, "Tracker"),
+        NavItem("settings", Icons.Outlined.Settings, "Settings")
     )
-    
+
     HorizontalFloatingToolbar(
-        modifier = modifier,
-        expanded = expanded,
-        colors = toolbarColors,
         floatingActionButton = {
             FloatingActionButton(
                 onClick = onFabClick,
@@ -93,49 +86,27 @@ fun ToolBarFAB(
                 )
             }
         },
-        floatingActionButtonPosition = FloatingToolbarHorizontalFabPosition.End,
-        content = {
-            // Analysis button
-            IconButton(
-                onClick = { navController.navigate("analysis") }
-            ) {
-                Icon(
-                    imageVector = Icons.Outlined.AutoGraph,
-                    contentDescription = "Analysis",
-                    tint = Color(0xFF38220F),
-                    modifier = Modifier.size(24.dp)
+        floatingActionButtonPosition = FloatingToolbarHorizontalFabPosition.End
+    ) {
+        items.forEach { item ->
+            NavigationBarItem(
+                selected = currentDestination == item.route,
+                onClick = {
+                    navController.navigate(item.route) {
+                        popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                },
+                icon = { Icon(item.icon, contentDescription = item.label) },
+                colors = NavigationBarItemDefaults.colors(
+                    selectedIconColor = Color(0xFFECE0D1),
+                    unselectedIconColor = Color(0xFF38220F),
+                    indicatorColor = Color(0xFF38220F)
                 )
-            }
-            
-            // Tracker button
-            IconButton(
-                colors = IconButtonColors(
-                    containerColor = Color(0xFF38220F),
-                    contentColor = Color(0xFF38220F),
-                    disabledContainerColor = Color(0xFFC5B5A6),
-                    disabledContentColor = Color(0xFF38220F)
-                ),
-                onClick = { }
-            ) {
-                Icon(
-                    imageVector = Icons.Outlined.Coffee,
-                    contentDescription = "Tracker",
-                    tint = Color(0xFFECE0D1),
-                    modifier = Modifier.size(24.dp)
-                )
-            }
-            
-            // Settings button
-            IconButton(
-                onClick = { navController.navigate("settings") }
-            ) {
-                Icon(
-                    imageVector = Icons.Outlined.Settings,
-                    contentDescription = "Settings",
-                    tint = Color(0xFF38220F),
-                    modifier = Modifier.size(24.dp)
-                )
-            }
+            )
         }
-    )
+    }
 }
+
+private data class NavItem(val route: String, val icon: ImageVector, val label: String)

--- a/Caffeine-in/app/src/main/java/com/example/caffeine_in/ui/navigation/CaffeineApp.kt
+++ b/Caffeine-in/app/src/main/java/com/example/caffeine_in/ui/navigation/CaffeineApp.kt
@@ -1,0 +1,52 @@
+package com.example.caffeine_in.ui.navigation
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FabPosition
+import androidx.compose.material3.Scaffold
+import androidx.compose.ui.graphics.Color
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import com.example.caffeine_in.ui.analysis.AnalysisScreen
+import com.example.caffeine_in.ui.caffeinetracker.CaffeineTrackerScreen
+import com.example.caffeine_in.ui.caffeinetracker.components.ToolBarFAB
+import com.example.caffeine_in.ui.info.InfoScreen
+import com.example.caffeine_in.ui.settings.SettingsScreen
+import com.example.caffeine_in.ui.settings.LicensesScreen
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun CaffeineApp() {
+    val navController = rememberNavController()
+    val currentDestination =
+        navController.currentBackStackEntryAsState().value?.destination?.route
+
+    Scaffold(
+        containerColor = Color(0xFFECE0D1),
+        floatingActionButtonPosition = FabPosition.Center,
+        floatingActionButton = {
+            ToolBarFAB(
+                navController = navController,
+                currentDestination = currentDestination,
+                onFabClick = { navController.navigate("tracker") }
+            )
+        }
+    ) { innerPadding ->
+        NavHost(
+            navController,
+            startDestination = "tracker",
+            modifier = Modifier.padding(innerPadding)
+        ) {
+            composable("tracker") { CaffeineTrackerScreen(navController) }
+            composable("analysis") { AnalysisScreen(navController) }
+            composable("settings") { SettingsScreen(navController) }
+            composable("info") { InfoScreen(navController) }
+            composable("licenses") { LicensesScreen(navController) }
+        }
+    }
+}

--- a/Caffeine-in/app/src/main/java/com/example/caffeine_in/ui/settings/SettingsScreen.kt
+++ b/Caffeine-in/app/src/main/java/com/example/caffeine_in/ui/settings/SettingsScreen.kt
@@ -1,9 +1,7 @@
 package com.example.caffeine_in.ui.settings
 
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -11,11 +9,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -59,28 +55,19 @@ fun SettingsScreen(navController: NavController) {
         )
     )
 
-    Scaffold(
-        containerColor = Color(0xFFECE0D1),
-        topBar = {
-            SettingsTopBar(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .statusBarsPadding(),
-                navController = navController
-            )
-        }
-    ) { innerPadding ->
-        val modifiedPadding = PaddingValues(
-            top = innerPadding.calculateTopPadding(),
-            start = innerPadding.calculateStartPadding(LocalLayoutDirection.current),
-            end = innerPadding.calculateEndPadding(LocalLayoutDirection.current),
-            bottom = 0.dp
+    Column(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        SettingsTopBar(
+            modifier = Modifier
+                .fillMaxWidth()
+                .statusBarsPadding(),
+            navController = navController
         )
 
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(modifiedPadding)
                 .padding(horizontal = 32.dp)
         ) {
             item {


### PR DESCRIPTION
## Summary
- replace IconButton toolbar items with NavigationBarItem and route highlighting
- add CaffeineApp scaffold hosting NavHost and floating toolbar
- update screens to use shared scaffold and remove per-screen bottom bars

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f0d4b1c883279e52971390fc34f4